### PR TITLE
Add allowed_formats 3 (and Drupal 10.1) compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 This changelog is incomplete. Pull requests with entries before 1.7.0
 are welcome.
 
+## [2.2.2] - 2023-01-01
+### Added
+- Compatibility with `drupal/allowed_formats:^3.0`
+
 ## [2.1.5] - 2023-06-21
 ### Added
 - Documentation on where subscribers are called

--- a/src/Plugin/Field/FieldWidget/MediaWidget.php
+++ b/src/Plugin/Field/FieldWidget/MediaWidget.php
@@ -382,13 +382,14 @@ class MediaWidget extends WidgetBase
             ];
 
             if (
-                $this->moduleHandler->moduleExists('allowed_formats')
-                && $item->getMedia()->hasField('field_description')
+                $item->getMedia()->hasField('field_description')
                 && ($fieldDefinition = $item->getMedia()->get('field_description')->getFieldDefinition())
-                && ($allowedFormats = $fieldDefinition->getThirdPartySettings('allowed_formats'))
+                && ($allowedFormats = $fieldDefinition->getThirdPartySettings('allowed_formats') ?: $fieldDefinition->getSetting('allowed_formats'))
             ) {
                 $row['data']['description']['#allowed_formats'] = $allowedFormats['allowed_formats'] ?? $allowedFormats;
-                $row['data']['description']['#after_build'] = ['_allowed_formats_remove_textarea_help'];
+                if ($this->moduleHandler->moduleExists('allowed_formats')) {
+                    $row['data']['description']['#after_build'] = ['_allowed_formats_remove_textarea_help'];
+                }
                 $row['data']['description']['#allowed_format_hide_settings'] = [
                     'hide_guidelines' => 1,
                     'hide_help' => 1,


### PR DESCRIPTION
## Description

In Drupal 10.1 the main feature of `drupal/allowed_formats` got added to core.
See https://www.drupal.org/node/3318572

To support it we have to check both the ThirdPartySettings (allowed_formats <= 2.x) and regular field settings (core >= 10.1).

We still check if `drupal/allowed_formats` is installed to hide the format description.
When https://www.drupal.org/i/3323007 lands, we can also remove that check 🎉 
