### PR TITLE
Convert media url to correct public link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 This changelog is incomplete. Pull requests with entries before 1.7.0
 are welcome.
 
+## [2.3.0] - 2024-XX-XX
+### Changed
+- wmmedia_file_link filter now requires a `/media` url to find the media entity
+- Deprecate MediaFileLink ckeditor plugin, this will not work on ckeditor 5
+
 ## [2.2.2] - 2023-01-01
 ### Added
 - Compatibility with `drupal/allowed_formats:^3.0`

--- a/src/Plugin/CKEditorPlugin/MediaFileLink.php
+++ b/src/Plugin/CKEditorPlugin/MediaFileLink.php
@@ -14,6 +14,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *     id = "media_file_link",
  *     label = @Translation("Media file link")
  * )
+ * @deprecated This plugin is deprecated and will be removed in a future release.
+ * Use drupal/ckeditor5_entity_browser instead to browse files for links.
  */
 class MediaFileLink extends CKEditorPluginBase implements ContainerFactoryPluginInterface
 {


### PR DESCRIPTION
## Description

The current `media_file_link` plugin for ckeditor has not been upgraded for ckeditor 5. 
Currently there is https://www.drupal.org/project/ckeditor5_entity_browser that does the same thing. We only need to change our `MediaFileLinkFilter` to swapout the `media/<nid>` to the correct public media link. 

## Related Issues

https://github.com/wieni/www.uzleuven.be/issues/220
