### PR TITLE
Fix field_media_file not found when adding the media link manually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 This changelog is incomplete. Pull requests with entries before 1.7.0
 are welcome.
 
-## [2.3.0] - 2024-XX-XX
+## [2.3.1] - 2024-05-06
+### Fixed
+- wmmedia_file_link filter does not break when getting a hardcoded media url
+
+## [2.3.0] - 2024-04-12
 ### Changed
 - wmmedia_file_link filter now requires a `/media` url to find the media entity
 - Deprecate MediaFileLink ckeditor plugin, this will not work on ckeditor 5

--- a/src/Plugin/Filter/MediaFileLinkFilter.php
+++ b/src/Plugin/Filter/MediaFileLinkFilter.php
@@ -50,9 +50,9 @@ class MediaFileLinkFilter extends FilterBase implements ContainerFactoryPluginIn
                 continue;
             }
 
-            preg_match('/(?<=media\/)\d+/', $href, $matches);
+            preg_match('/media\/(\d+)(?:\/)?(?:edit)?$/', $href, $matches);
 
-            $mid = reset($matches);
+            $mid = end($matches);
 
             if (!$mid) {
                 continue;
@@ -60,7 +60,10 @@ class MediaFileLinkFilter extends FilterBase implements ContainerFactoryPluginIn
 
             $media = $storage->load($mid);
 
-            if (!$media instanceof Media) {
+            if (
+                !$media instanceof Media
+                || !$media->hasField('field_media_file')
+            ) {
                 continue;
             }
 


### PR DESCRIPTION
## Description

#### problem: 

media url saved: https://www.uzleuven.be/nl/media/1b2252ee-696c-4ce5-ba6b-8b431a644476/EudraCT_Annex2.pdf
this matches with the current regex

#### solution: 

updated regex and added extra check

## Related Issues

related to https://github.com/wieni/www.uzleuven.be/issues/264 
