### PR TITLE
#51 implement HOOK_ckeditor5_entity_browser_definitions_alter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,17 @@
         "ergebnis/composer-normalize": "^2.0",
         "wieni/wmcodestyle": "^1.0"
     },
+    "conflict": {
+        "drupal/ckeditor5_entity_browser": "<1.0.2"
+    },
     "repositories": {
         "drupal-composer": {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
         }
+    },
+    "suggest": {
+        "drupal/ckeditor5_entity_browser": "Allows embedding media (files) in CKEditor 5 using Entity Browser"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/wmmedia.module
+++ b/wmmedia.module
@@ -2,6 +2,7 @@
 
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
 use Drupal\image\Entity\ImageStyle;
 use Drupal\media\Entity\Media;
 use Drupal\wmmedia\Plugin\Field\FieldType\MediaImageExtras;
@@ -225,4 +226,25 @@ function _wmmedia_theme_is_active(string $themeNameToCheck): bool
     }
 
     return array_key_exists($themeNameToCheck, $themeNames);
+}
+
+function wmmedia_ckeditor5_entity_browser_definitions_alter(array &$definitions): void
+{
+    // drupal/ckeditor5_entity_browser uses the configured entity browser's
+    // Display URL (iframe/modal/etc) when opening the ckeditor dialog.
+    // We already have a custom route that's meant to be opened in a dialog,
+    // so let's use that instead.
+    // This is a workaround until we can provide a better solution, such as
+    // creating our own EntityBrowserDisplay plugin for entity_browser.
+    foreach ($definitions as $entity_browser_id => $config) {
+        // These are the entity browsers that wmmedia currently provides.
+        if (in_array($entity_browser_id, ['files_editor', 'files'])) {
+            // We also want to use a different label for the button that opens
+            // the dialog.
+            $definitions[$entity_browser_id]['label'] = t('Add Files');
+            // Alter the dialog url to use our custom route.
+            // This requires https://www.drupal.org/project/ckeditor5_entity_browser/issues/3445512
+            $definitions[$entity_browser_id]['browser_display_url'] = Url::fromRoute('wmmedia.file.browser.editor')->toString();
+        }
+    }
 }


### PR DESCRIPTION
## Description

In https://github.com/wieni/wmmedia/pull/49 we've decided to no longer maintain a custom ckeditor javascript plugin.
Instead we rely on `drupal/ckeditor5_entity_browser` to show the file entity browser dialog modal.

`drupal/ckeditor5_entity_browser` opens a dialog by calling `/entity-browser/modal/file_editor`.
That route doesn't exist because our `file_editor` entity browser is [configured to be an iframe](https://github.com/wieni/wmmedia/blob/3143ad2dad663e2d04411647c69cf4f617f0098c/config/install/entity_browser.browser.files_editor.yml#L11), not a modal.
That's being fixed upstream in [#3445512](https://www.drupal.org/project/ckeditor5_entity_browser/issues/3445512), but that's still a problem for us.

We have a custom `wmmedia.file.browser.editor` route intended to be called by the ckeditor dialog.
This route isn't being used at all anymore and is causing issues.

For example, [the "Upload"](https://github.com/wieni/wmmedia/assets/9056689/4c4597c3-b1d0-4770-9ddd-2118cf865043) tab isn't being rendered anymore.
And when you search, you're being sent to a different web page because the modal isn't rendering an iframe.

### Steps to reproduce

Configure `ckeditor5_entity_browser` to show the `file_editor` entity browser.
Add a file link by triggering the entity browser modal, and search for a string.
You'll notice you're leaving the ckeditor context.

<details><summary>Video</summary>

https://github.com/wieni/wmmedia/assets/9056689/c3280572-b015-4461-b93b-f1633db1c57d

</details> 

### Expected result

Our `wmmedia.file.browser.editor` route should be rendered.
It attaches the correct libraries to use the entity browser in a modal.
