### PR TITLE
#58 Use correct array keys after media refactor

### DIFF
--- a/src/Service/ImageOverviewFormBuilder.php
+++ b/src/Service/ImageOverviewFormBuilder.php
@@ -98,9 +98,9 @@ class ImageOverviewFormBuilder extends OverviewFormBuilderBase
                 '#markup' => '<p>' . $image['name'] . '</p>',
             ];
 
-            if ($image['field_width_value']) {
+            if (isset($image['field_width'], $image['field_height'])) {
                 $form['container']['list'][$key]['dimensions'] = [
-                    '#markup' => sprintf('<p>%s x %s</p>', $image['field_width_value'], $image['field_height_value']),
+                    '#markup' => sprintf('<p>%s x %s</p>', $image['field_width'], $image['field_height']),
                 ];
             }
         }


### PR DESCRIPTION
In #58 we moved the media fields to basefields to improve the overview query performance.
However it seems we also changed the aliases of the columns and forgot to update our usage.

