### PR TITLE
Alter the update hook that migrates to base fields

### DIFF
--- a/wmmedia.install
+++ b/wmmedia.install
@@ -380,21 +380,22 @@ function wmmedia_update_8009(): void
         }
     }
 
-    $fields_to_purge = [
-      'media.image.field_alternate',
-      'media.image.field_description',
-      'media.image.field_height',
-      'media.image.field_width',
-      'media.image.field_copyright',
-      'media.image.field_copyright',
+    $fieldsToPurge = [
+        'media.image.field_alternate',
+        'media.image.field_description',
+        'media.image.field_height',
+        'media.image.field_width',
+        'media.image.field_copyright',
+        'media.image.field_copyright',
     ];
-    // Purge the field definitions we just deleted.
+    // Remove deleted fields from the deleted fields repository. They are
+    // not *really* deleted, but being migrated to base fields.
     /** @var \Drupal\Core\Field\DeletedFieldsRepositoryInterface $deletedFieldsRepository */
     $deletedFieldsRepository = \Drupal::service('entity_field.deleted_fields_repository');
     foreach ($deletedFieldsRepository->getFieldDefinitions() as $deletedFieldDefinition) {
-      if (in_array($deletedFieldDefinition->id(), $fields_to_purge)) {
-        $deletedFieldsRepository->removeFieldDefinition($deletedFieldDefinition);
-      }
+        if (in_array($deletedFieldDefinition->id(), $fieldsToPurge)) {
+            $deletedFieldsRepository->removeFieldDefinition($deletedFieldDefinition);
+        }
     }
 
     // Now the fields are deleted, we can register the base fields.
@@ -469,22 +470,23 @@ function wmmedia_update_8009(): void
 }
 
 /**
- * Purge deleted fields that are causing issues with the Field purge cron job.
+ * Remove migrated fields from the deleted fields repository. They were
+ * not *really* deleted, but migrated to base fields.
  */
 function wmmedia_update_8010(): void {
-  $fields_to_purge = [
-    'media.image.field_alternate',
-    'media.image.field_description',
-    'media.image.field_height',
-    'media.image.field_width',
-    'media.image.field_copyright',
-    'media.image.field_copyright',
-  ];
-  /** @var \Drupal\Core\Field\DeletedFieldsRepositoryInterface $deletedFieldsRepository */
-  $deletedFieldsRepository = \Drupal::service('entity_field.deleted_fields_repository');
-  foreach ($deletedFieldsRepository->getFieldDefinitions() as $deletedFieldDefinition) {
-    if (in_array($deletedFieldDefinition->id(), $fields_to_purge)) {
-      $deletedFieldsRepository->removeFieldDefinition($deletedFieldDefinition);
+    $fieldsToPurge = [
+      'media.image.field_alternate',
+      'media.image.field_description',
+      'media.image.field_height',
+      'media.image.field_width',
+      'media.image.field_copyright',
+      'media.image.field_copyright',
+    ];
+    /** @var \Drupal\Core\Field\DeletedFieldsRepositoryInterface $deletedFieldsRepository */
+    $deletedFieldsRepository = \Drupal::service('entity_field.deleted_fields_repository');
+    foreach ($deletedFieldsRepository->getFieldDefinitions() as $deletedFieldDefinition) {
+        if (in_array($deletedFieldDefinition->id(), $fieldsToPurge)) {
+            $deletedFieldsRepository->removeFieldDefinition($deletedFieldDefinition);
+        }
     }
-  }
 }


### PR DESCRIPTION
## Description

We noticed, that after migrating the media fields to base fields, the purging of the fields cannot run, because we created the fields with the same name. This change purges the fields after we deleted them. We also added another hook update, for projects that already ran the hook_update_8009

