### PR TITLE
Fix field_copyright not being registered

### DIFF
--- a/wmmedia.install
+++ b/wmmedia.install
@@ -423,7 +423,7 @@ function wmmedia_update_8009(): void
     $fieldManager->clearCachedFieldDefinitions();
     $fieldStorageDefinitions = $fieldManager->getFieldStorageDefinitions('media');
 
-    foreach ($existingFields as $field) {
+    foreach (['field_alternate', 'field_description', 'field_height', 'field_width', 'field_copyright'] as $field) {
         if (!isset($fieldStorageDefinitions[$field])) {
             throw new \RuntimeException("Field storage definition for {$field} not found.");
         }


### PR DESCRIPTION
## Description

Error occurs on media overview after an update. 

```
Column not found: 1054 Unknown column 'd.field_copyright__value' in 'SELECT': SELECT "m"."mid" AS "mid", "d"."name" AS "name", "d"."field_copyright__value" AS "field_copyright", "d"."field_description__value" AS "field_description", "d"."field_width" AS "field_width", "d"."field_height" AS "field_height", "field_image"."field_image_target_id" AS "field_image_target_id", EXISTS(SELECT u.media_id FROM wmmedia_usage AS u WHERE u.media_id = m.mid) AS "in_use" FROM "media" "m" INNER JOIN "media_field_data" "d" ON m.mid = d.mid INNER JOIN "media__field_image" "field_image" ON m.mid = field_image.entity_id WHERE "m"."bundle" = :db_condition_placeholder_0 ORDER BY "m"."mid" DESC LIMIT 20 OFFSET 0; Array ( [:db_condition_placeholder_0] => image ) in Drupal\wmmedia\Service\ImageRepository->getImages() (line 42 of modules/contrib/wmmedia/src/Service/ImageRepository.php).
```

## Related Issues

Uzleuven drupal update
